### PR TITLE
Disable import/no-duplicates in favor of prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,8 @@ module.exports = {
     'import/default': 0,
     'import/named': 0,
     'import/namespace': 0,
-    'import/no-duplicates': 2,
+    // prettier https://github.com/ianvs/prettier-plugin-sort-imports already handles it.
+    'import/no-duplicates': 0, 
     'import/no-extraneous-dependencies': 2,
     'import/no-named-as-default-member': 0,
     'import/no-namespace': 2,

--- a/index.js
+++ b/index.js
@@ -53,11 +53,10 @@ module.exports = {
     ],
     curly: 2,
     'eol-last': 2,
-    // `import/default` and `import/namespace` are slow.
+    // `import/default`, `import/namespace` and `import/no-duplicates` are slow.
     'import/default': 0,
     'import/named': 0,
     'import/namespace': 0,
-    // prettier https://github.com/ianvs/prettier-plugin-sort-imports already handles it.
     'import/no-duplicates': 0, 
     'import/no-extraneous-dependencies': 2,
     'import/no-named-as-default-member': 0,


### PR DESCRIPTION
Context:

i was debugging why my vscode is sluggish and i found out a quick win here.

In my repo the top rule is `import/no-duplicates`.

![image](https://github.com/cpojer/eslint-config/assets/6432326/3c9df8b3-416f-4189-a5b9-65327690ff18)

but this case is already handled by prettier prettier-plugin-sort-imports and will be detected by prettier --check on the CI/CD