### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Christoph Nakazawa <christoph.pojer@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "git://github.com/cpojer/eslint-config.git"
+    "url": "git+https://github.com/cpojer/eslint-config.git"
   },
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- update the package repository URL from legacy `git://` to public `git+https`
- keep runtime code, dependencies, package version, entry point, and package contents unchanged

## Validation
- npm view @nkzw/eslint-config --json
- checked for duplicate upstream PRs/issues and Charles issues before submission
- node metadata assertion
- git diff --check
- COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm install --frozen-lockfile --ignore-scripts
- COREPACK_ENABLE_PROJECT_SPEC=0 corepack pnpm run lint
- npm pack --dry-run --ignore-scripts --json .