### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Christoph Nakazawa <christoph.pojer@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "git://github.com/cpojer/eslint-config.git"
+    "url": "git+https://github.com/nkzw-tech/eslint-config.git"
   },
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Updates the package repository metadata to use the current public GitHub repository over HTTPS instead of the legacy `git://` URL.

Verification:
- `./node_modules/.bin/eslint -c index.js .`